### PR TITLE
Add Google AI spellcheck integration

### DIFF
--- a/html/config.html
+++ b/html/config.html
@@ -36,6 +36,21 @@
                     <input type="text" name="supabaseKeyTest" />
                 </label>
             </div>
+            <div id="aiFields" class="env-block">
+                <h3>Google AI Studio</h3>
+                <label class="full">API Key
+                    <input type="text" name="aiKey" />
+                </label>
+                <label>Modelo
+                    <input type="text" name="aiModel" />
+                </label>
+                <label>Idioma correcci&oacute;n
+                    <select name="aiLang">
+                        <option value="es">Castellano</option>
+                        <option value="ca">Catal&aacute;n</option>
+                    </select>
+                </label>
+            </div>
             <footer class="full">
                 <button type="submit" class="Buttons primary">Guardar</button>
             </footer>

--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
     <!-- Scripts -->
     <script src="js/conection-bbdd.js"></script>
     <script src="js/config.js"></script>
+    <script src="js/spellcheck.js"></script>
     <script src="js/data-loader.js"></script>
     <script src="js/impute-hours.js"></script>
     <script src="js/customers.js"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,6 @@
 /*************** Configuración Supabase ****************/
 window.supabaseCreds = { url: '', key: '' };
+window.aiConfig = { key: '', model: '', lang: 'es' };
 let currentConfigBackdrop = null;
 
 function loadSupabaseCreds() {
@@ -9,6 +10,13 @@ function loadSupabaseCreds() {
   window.supabaseCreds.url = url;
   window.supabaseCreds.key = key;
   document.dispatchEvent(new Event('credsLoaded'));
+}
+
+function loadAiConfig() {
+  window.aiConfig.key = localStorage.getItem('aiKey') || '';
+  window.aiConfig.model = localStorage.getItem('aiModel') || '';
+  window.aiConfig.lang = localStorage.getItem('aiLang') || 'es';
+  document.dispatchEvent(new Event('aiConfigLoaded'));
 }
 
 function openConfigPopup() {
@@ -36,6 +44,9 @@ function openConfigPopup() {
       const keyTest = form.elements['supabaseKeyTest'];
       const realBlock = form.querySelector('#realFields');
       const testBlock = form.querySelector('#testFields');
+      const aiKey = form.elements['aiKey'];
+      const aiModel = form.elements['aiModel'];
+      const aiLang = form.elements['aiLang'];
 
       function updateFields() {
         const env = envSel.value;
@@ -59,6 +70,9 @@ function openConfigPopup() {
       envSel.value = localStorage.getItem('supabaseEnv') || 'real';
       updateFields();
       envSel.addEventListener('change', updateFields);
+      aiKey.value = localStorage.getItem('aiKey') || '';
+      aiModel.value = localStorage.getItem('aiModel') || '';
+      aiLang.value = localStorage.getItem('aiLang') || 'es';
 
       function closePopup() {
         backdrop.remove();
@@ -77,6 +91,9 @@ function openConfigPopup() {
         const keyR = keyReal.value.trim();
         const urlT = urlTest.value.trim();
         const keyT = keyTest.value.trim();
+        const aiK = aiKey.value.trim();
+        const aiM = aiModel.value.trim();
+        const aiL = aiLang.value;
 
         if (env === 'real' && (!urlR || !keyR)) {
           alert('Debe introducir URL y KEY de Real');
@@ -92,8 +109,12 @@ function openConfigPopup() {
         if (keyR) localStorage.setItem('supabaseKeyReal', keyR);
         if (urlT) localStorage.setItem('supabaseUrlTest', urlT);
         if (keyT) localStorage.setItem('supabaseKeyTest', keyT);
+        if (aiK) localStorage.setItem('aiKey', aiK); else localStorage.removeItem('aiKey');
+        if (aiM) localStorage.setItem('aiModel', aiM); else localStorage.removeItem('aiModel');
+        localStorage.setItem('aiLang', aiL);
 
         loadSupabaseCreds();
+        loadAiConfig();
         document.dispatchEvent(new Event('configSaved'));
         closePopup();
       });
@@ -117,6 +138,6 @@ function updateEnvLabel() {
     label.classList.remove('test');
   }
 }
-document.addEventListener('DOMContentLoaded', () => { loadSupabaseCreds(); updateEnvLabel(); });
-document.addEventListener('configSaved', () => { loadSupabaseCreds(); updateEnvLabel(); });
+document.addEventListener('DOMContentLoaded', () => { loadSupabaseCreds(); loadAiConfig(); updateEnvLabel(); });
+document.addEventListener('configSaved', () => { loadSupabaseCreds(); loadAiConfig(); updateEnvLabel(); });
 window.updateEnvLabel = updateEnvLabel;

--- a/js/impute-hours.js
+++ b/js/impute-hours.js
@@ -335,7 +335,7 @@ Array.from(document.querySelectorAll('#filterPane li[data-filter]')).forEach(li 
 document.getElementById('searchFilter').addEventListener('input', () => renderImputations());
 
 // Crear imputación abierta
-function createOpenImputation(inDate, taskId, comments = '', noFee = false) {
+async function createOpenImputation(inDate, taskId, comments = '', noFee = false) {
   const ri = round15(inDate);
   const task = tasks.find(t => t.id == taskId);
   const customer = task ? customers.find(c => c.no === task.customerNo) : null;
@@ -357,6 +357,7 @@ function createOpenImputation(inDate, taskId, comments = '', noFee = false) {
     minimumMonthlyHours: customer ? customer.minimumMonthlyHours : 0,
     minimumDailyHours: customer ? customer.minimumDailyHours : 0
   });
+  await applySpellcheck('imputations', rec, {});
   selectedImputationId = rec.id;
   return db.insert('imputations', {
     ...sanitizeStrings({
@@ -504,6 +505,7 @@ async function updateImputation(id, inDate, outDate, taskId, comments, noFeeChec
       isVacation: isCalendarVacation(ri)
     });
   }
+  await applySpellcheck('imputations', data, rec);
   selectedImputationId = id;
   await db.update('imputations', { id }, data).then(() => loadFromDb()).catch(console.error);
 }
@@ -531,6 +533,7 @@ async function createManualImputation(inDate, outDate, taskId, comments, noFeeCh
     minimumMonthlyHours: customer ? customer.minimumMonthlyHours : 0,
     minimumDailyHours: customer ? customer.minimumDailyHours : 0
   });
+  await applySpellcheck('imputations', rec, {});
   selectedImputationId = rec.id;
   await db.insert('imputations', {
     ...sanitizeStrings({

--- a/js/spellcheck.js
+++ b/js/spellcheck.js
@@ -1,0 +1,39 @@
+// Spell checking via Google AI Studio
+window.SPELLCHECK_FIELDS = {
+  imputations: ['comments'],
+  tasks: ['taskDescription']
+};
+
+async function correctTextWithAI(text) {
+  if (!window.aiConfig || !aiConfig.key || !aiConfig.model) return text;
+  if (!text) return text;
+  const prompt = `Corrige las faltas de ortograf\u00EDa del siguiente texto en ${aiConfig.lang}. No omitas palabras y devuelve solo el texto corregido.`;
+  const body = {
+    contents: [{ parts: [{ text: `${prompt}\n\n${text}` }] }],
+    generationConfig: { temperature: 0 }
+  };
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${aiConfig.model}:generateContent?key=${aiConfig.key}`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+    );
+    const data = await res.json();
+    return data?.candidates?.[0]?.content?.parts?.[0]?.text || text;
+  } catch (err) {
+    console.error(err);
+    return text;
+  }
+}
+
+window.applySpellcheck = async function (table, data, original = {}) {
+  const fields = SPELLCHECK_FIELDS[table];
+  if (!fields) return data;
+  for (const f of fields) {
+    const val = data[f];
+    const prev = original[f] ?? '';
+    if (typeof val === 'string' && val.trim() && val !== prev) {
+      data[f] = await correctTextWithAI(val);
+    }
+  }
+  return data;
+};

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -154,6 +154,7 @@ function openTaskModal(task = null, onSave) {
     data.noCharge = form.elements["noCharge"].checked;
     data.completed = form.elements["completed"].checked;
     data.id = Number(form.elements["id"].value);
+    await applySpellcheck('tasks', data, task || {});
     let savedId;
     try {
       if (task) {


### PR DESCRIPTION
## Summary
- extend config modal with Google AI settings
- load/save API key, model and language in `config.js`
- implement generic spellcheck module
- apply spellcheck when saving tasks and imputations
- include new script in `index.html`

## Testing
- `node -c js/spellcheck.js`
- `node -c js/config.js`
- `node -c js/impute-hours.js`
- `node -c js/tasks.js`


------
https://chatgpt.com/codex/tasks/task_e_6887bc200ffc8330be0f9ef7d1291a2d