### PR TITLE
Add company monthly calculation tool

### DIFF
--- a/html/company-calculator.html
+++ b/html/company-calculator.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Cálculo mensual</title>
+    <link rel="icon" type="image/png" href="assets/favicon.png" />
+</head>
+
+<body>
+    <div id="companyCalcPage">
+        <header>
+            <span class="modal-title">Cálculo mensual</span>
+            <button class="close" type="button">×</button>
+        </header>
+        <form id="calcForm">
+            <label>Horas mínimas
+                <input type="number" step="0.01" name="minimumHours" />
+            </label>
+            <label>Cliente
+                <select name="customerNo"></select>
+            </label>
+            <label>Precio hora
+                <input type="number" step="0.01" name="priceHour" />
+            </label>
+            <label>% IVA
+                <input type="number" step="0.01" name="vat" />
+            </label>
+            <label>% IRPF
+                <input type="number" step="0.01" name="irpf" />
+            </label>
+            <label>Importe pendiente
+                <input type="number" step="0.01" name="pending" readonly />
+            </label>
+            <label>Importe IVA
+                <input type="number" step="0.01" name="vatAmount" readonly />
+            </label>
+            <label>Importe IRPF
+                <input type="number" step="0.01" name="irpfAmount" readonly />
+            </label>
+            <label>Importe autónomos
+                <input type="number" step="0.01" name="amountAutonomos" />
+            </label>
+            <label>Delme
+                <input type="number" step="0.01" name="tithe" readonly />
+            </label>
+            <label>Nómina
+                <input type="number" step="0.01" name="amountNomina" />
+            </label>
+            <label>Importe renta
+                <input type="number" step="0.01" name="incomeAmount" />
+            </label>
+            <label>Extras
+                <input type="number" step="0.01" name="extraAmounts" />
+            </label>
+            <label class="full">Resultado
+                <input type="number" step="0.01" name="result" readonly />
+            </label>
+        </form>
+    </div>
+</body>
+
+</html>

--- a/html/company.html
+++ b/html/company.html
@@ -51,6 +51,15 @@
                         <label>% diezmo
                             <input type="number" step="0.01" name="tithePercent" />
                         </label>
+                        <label>Horas mínimas mes
+                            <input type="number" step="0.01" name="minimumHoursMonth" />
+                        </label>
+                        <label>Importe renta
+                            <input type="number" step="0.01" name="incomeAmount" />
+                        </label>
+                        <label>Importes extras
+                            <input type="number" step="0.01" name="extraAmounts" />
+                        </label>
                         <label>Email
                             <input type="email" name="email" />
                         </label>
@@ -65,6 +74,7 @@
                         </label>
                         <footer class="full">
                             <button type="submit" class="Buttons primary">Guardar</button>
+                            <button type="button" class="Buttons" id="btnCompanyCalc">Cálculo mensual</button>
                         </footer>
                     </form>
                 </div>

--- a/index.html
+++ b/index.html
@@ -165,6 +165,7 @@
     <script src="js/calendar.js"></script>
     <script src="js/calendar-year.js"></script>
     <script src="js/company.js"></script>
+    <script src="js/company-calculator.js"></script>
     <script src="js/invoice-print.js"></script>
     <script src="js/invoices.js"></script>
 </body>

--- a/js/company-calculator.js
+++ b/js/company-calculator.js
@@ -1,0 +1,118 @@
+/*************** Cálculo mensual de empresa ****************/
+let currentCompanyCalcBackdrop = null;
+
+function openCompanyCalcPopup() {
+  if (currentCompanyCalcBackdrop) {
+    currentCompanyCalcBackdrop.remove();
+    currentCompanyCalcBackdrop = null;
+  }
+
+  fetch("html/company-calculator.html")
+    .then(r => r.text())
+    .then(html => {
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const page = doc.getElementById('companyCalcPage');
+      const backdrop = document.createElement('div');
+      backdrop.className = 'modal-backdrop';
+      const modal = document.createElement('div');
+      modal.className = 'modal';
+      modal.appendChild(page);
+      backdrop.appendChild(modal);
+      document.body.appendChild(backdrop);
+      currentCompanyCalcBackdrop = backdrop;
+
+      const form = backdrop.querySelector('#calcForm');
+      const f = form.elements;
+
+      // populate company defaults
+      f.minimumHours.value = company.minimumHoursMonth || 0;
+      f.amountAutonomos.value = company.amountAutonomos || 0;
+      f.amountNomina.value = company.amountNomina || 0;
+      f.incomeAmount.value = company.incomeAmount || 0;
+      f.extraAmounts.value = company.extraAmounts || 0;
+
+      // populate customers select
+      customers.forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c.no;
+        opt.textContent = `${c.no} - ${c.name}`;
+        f.customerNo.appendChild(opt);
+      });
+      if (customers.length) f.customerNo.value = customers[0].no;
+
+      function loadCustomer(no) {
+        const c = customers.find(x => x.no == no) || {};
+        f.priceHour.value = c.priceHour || 0;
+        f.vat.value = c.vat || 0;
+        f.irpf.value = c.irpf || 0;
+        recalc();
+      }
+
+      f.customerNo.addEventListener('change', e => loadCustomer(e.target.value));
+
+      const fieldsToWatch = [
+        'minimumHours', 'priceHour', 'vat', 'irpf', 'amountAutonomos',
+        'amountNomina', 'incomeAmount', 'extraAmounts'
+      ];
+      fieldsToWatch.forEach(n => f[n].addEventListener('input', recalc));
+
+      function recalc() {
+        const minHours = parseFloat(f.minimumHours.value) || 0;
+        const price = parseFloat(f.priceHour.value) || 0;
+        const vat = parseFloat(f.vat.value) || 0;
+        const irpf = parseFloat(f.irpf.value) || 0;
+        const autonomos = parseFloat(f.amountAutonomos.value) || 0;
+        const nomina = parseFloat(f.amountNomina.value) || 0;
+        const renta = parseFloat(f.incomeAmount.value) || 0;
+        const extras = parseFloat(f.extraAmounts.value) || 0;
+        const pending = minHours * price;
+        const vatAmount = pending * vat / 100;
+        const irpfAmount = pending * irpf / 100;
+        const delmeBase = pending - irpfAmount - autonomos;
+        const delme = Math.ceil(delmeBase * (company.tithePercent || 0) / 100);
+        const result = pending - (irpfAmount + autonomos + delme + nomina + renta + extras);
+        f.pending.value = pending.toFixed(2);
+        f.vatAmount.value = vatAmount.toFixed(2);
+        f.irpfAmount.value = irpfAmount.toFixed(2);
+        f.tithe.value = delme.toFixed(2);
+        f.result.value = result.toFixed(2);
+      }
+
+      if (customers.length) loadCustomer(f.customerNo.value);
+      else recalc();
+
+      const closeBtn = backdrop.querySelector('.close');
+      function close() {
+        backdrop.remove();
+        currentCompanyCalcBackdrop = null;
+        document.removeEventListener('keydown', handleEsc);
+      }
+      function handleEsc(e) { if (e.key === 'Escape') close(); }
+      document.addEventListener('keydown', handleEsc);
+      closeBtn.addEventListener('click', close);
+    });
+}
+
+function calculateClientHoursResult(clientNo, hours) {
+  const client = customers.find(c => c.no == clientNo);
+  if (!client) return null;
+  const price = client.priceHour || 0;
+  const vat = client.vat || 0;
+  const irpf = client.irpf || 0;
+  const pending = hours * price;
+  const vatAmount = pending * vat / 100;
+  const irpfAmount = pending * irpf / 100;
+  const autonomos = company.amountAutonomos || 0;
+  const delmeBase = pending - irpfAmount - autonomos;
+  const delme = Math.ceil(delmeBase * (company.tithePercent || 0) / 100);
+  const nomina = company.amountNomina || 0;
+  const renta = company.incomeAmount || 0;
+  const extras = company.extraAmounts || 0;
+  const result = pending - (irpfAmount + autonomos + delme + nomina + renta + extras);
+  return {
+    pending, vatAmount, irpfAmount, delme, result
+  };
+}
+
+window.openCompanyCalcPopup = openCompanyCalcPopup;
+window.calculateClientHoursResult = calculateClientHoursResult;

--- a/js/company.js
+++ b/js/company.js
@@ -46,10 +46,13 @@ function openCompanyModal(tmpl) {
   document.addEventListener('keydown', handleEsc);
   bd.querySelector(".close").addEventListener("click", closeModal);
 
+  const btnCalc = form.querySelector("#btnCompanyCalc");
+  if (btnCalc) btnCalc.addEventListener("click", () => { if (window.openCompanyCalcPopup) openCompanyCalcPopup(); });
+
   form.addEventListener("submit", async e => {
     e.preventDefault();
     const data = sanitizeStrings(Object.fromEntries(new FormData(form).entries()));
-    ["amountAutonomos", "totalVacationDays", "amountNomina", "tithePercent"]
+    ["amountAutonomos", "totalVacationDays", "amountNomina", "tithePercent", "minimumHoursMonth", "incomeAmount", "extraAmounts"]
       .forEach(f => data[f] = parseFloat(data[f] || 0));
     try {
       if (Object.prototype.hasOwnProperty.call(company, 'id')) {


### PR DESCRIPTION
## Summary
- add minimum hours, renta and extras fields in company data
- create monthly calculation popup with editable fields and real-time totals
- expose helper to calculate client-hour results programmatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943f7bd0f88330ba11a75813919a5e