### PR TITLE
Support rectifying invoices with negative totals

### DIFF
--- a/html/invoice-print.html
+++ b/html/invoice-print.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Factura {{NO}}</title>
+  <title>{{TYPE}} {{NO}}</title>
   <link rel="stylesheet" href="css/invoice-print.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -14,7 +14,7 @@
 <body>
   <div class="invoice-container">
     <header class="main-header">
-      <h1>FACTURA</h1>
+      <h1>{{TYPE}}</h1>
       <div class="invoice-details">
         <div><span>FECHA:</span> <span>{{DATE}}</span></div>
         <div><span>NÚMERO:</span> <span>{{NO}}</span></div>

--- a/js/invoice-print.js
+++ b/js/invoice-print.js
@@ -81,146 +81,151 @@ async function printInvoice(inv) {
             <div class="final-total"><span class="total-label">TOTAL</span> <span>${fmtCurrency(totalAmount)}</span></div>
         `;
 
+        const isRectificativa = totalAmount < 0;
+        const typeLabel = isRectificativa ? i18n.t('Factura rectificativa') : i18n.t('Factura');
+
         // --- Lógica de imputaciones mejorada ---
-        const invoiceDate = new Date(inv.date);
-        console.log('Fecha de factura:', {
-            fecha: invoiceDate,
-            año: invoiceDate.getFullYear(),
-            mes: invoiceDate.getMonth() + 1,
-            timestamp: invoiceDate.getTime()
-        });
-
-        // Filtrar imputaciones
-        const imps = imputations.filter(imp => {
-            if (!imp || !imp.date) {
-                console.log(i18n.t('Imputación inválida:'), imp);
-                return false;
-            }
-
-            // Normalizar la fecha de la imputación
-            const impDate = imp.date instanceof Date ? imp.date : new Date(imp.date);
-            const task = tasks.find(t => t.id === imp.taskId);
-
-            // Obtener año y mes normalizados
-            const impYear = impDate.getFullYear();
-            const impMonth = impDate.getMonth();
-            const invYear = invoiceDate.getFullYear();
-            const invMonth = invoiceDate.getMonth();
-
-            const matchYear = impYear === invYear;
-            const matchMonth = impMonth === invMonth;
-            const matchCustomer = task && task.customerNo === inv.customerNo;
-
-            console.log(i18n.t('Evaluando imputación:'), {
-                id: imp.id,
-                fecha_original: imp.date,
-                fecha_normalizada: impDate,
-                año: impYear,
-                mes: impMonth + 1,
-                fecha_factura: invoiceDate,
-                año_factura: invYear,
-                mes_factura: invMonth + 1,
-                coincideAño: matchYear,
-                coincideMes: matchMonth,
-                coincideCliente: matchCustomer,
-                taskId: imp.taskId,
-                task: task,
-                customerNo: task?.customerNo,
-                customerFactura: inv.customerNo
-            });
-
-            const matches = matchYear && matchMonth && matchCustomer;
-            console.log(`Imputación ${imp.id} ${matches ? 'COINCIDE' : 'NO COINCIDE'}`);
-
-            return matches;
-        }).sort((a, b) => {
-            const dateA = a.date instanceof Date ? a.date : new Date(a.date);
-            const dateB = b.date instanceof Date ? b.date : new Date(b.date);
-            return dateA - dateB;
-        });
-
-        console.log('Imputaciones filtradas:', {
-            total: imps.length,
-            imputaciones: imps.map(imp => ({
-                id: imp.id,
-                fecha: imp.date,
-                taskId: imp.taskId,
-                task: tasks.find(t => t.id === imp.taskId)?.subject
-            }))
-        });
-
-        // Generar HTML de imputaciones
         let impsSectionHtml = '';
         let pageTotal = 1; // al menos la página de la factura
-        if (imps.length > 0) {
-            const rowsArray = (inv.arrayLinesInvoicePrint || '').split(',')
-                .map(n => parseInt(n.trim(), 10))
-                .filter(n => !isNaN(n) && n > 0);
-            const ROWS_PER_PAGE_DEFAULT = 25;
-            const rowsPerPage = rowsArray.length > 0 ? rowsArray : [ROWS_PER_PAGE_DEFAULT];
-            const headerHtml = `
-                <header class="main-header">
-                    <h1>FACTURA</h1>
-                    <div class="invoice-details">
-                        <div><span>FECHA:</span> <span>${fmtDate(inv.date)}</span></div>
-                        <div><span>NÚMERO:</span> <span>${inv.no}</span></div>
-                    </div>
-                </header>`;
+        if (!isRectificativa) {
+            const invoiceDate = new Date(inv.date);
+            console.log('Fecha de factura:', {
+                fecha: invoiceDate,
+                año: invoiceDate.getFullYear(),
+                mes: invoiceDate.getMonth() + 1,
+                timestamp: invoiceDate.getTime()
+            });
 
-            const makeRow = rec => {
-                const task = tasks.find(t => t.id === rec.taskId) || {};
-                const sinCargo = (rec.noFee || task.noCharge) ? i18n.t('Sí') : '';
-                const taskLabel = task.clientTaskNo || task.subject || '';
-                return `<tr>
-                    <td>${fmtDate(rec.date)}</td>
-                    <td>${taskLabel}</td>
-                    <td>${rec.comments || ''}</td>
-                    <td style="text-align: right;">${fmtNum(rec.totalDecimal)}</td>
-                    <td style="text-align: center;">${sinCargo}</td>
-                </tr>`;
-            };
+            // Filtrar imputaciones
+            const imps = imputations.filter(imp => {
+                if (!imp || !imp.date) {
+                    console.log(i18n.t('Imputación inválida:'), imp);
+                    return false;
+                }
 
-            const pageData = [];
-            let idx = 0;
-            let page = 0;
-            while (idx < imps.length) {
-                const rowsThisPage = rowsPerPage[Math.min(page, rowsPerPage.length - 1)];
-                const pageRows = imps.slice(idx, idx + rowsThisPage).map(makeRow).join('');
-                pageData.push({
-                    num: page + 1,
-                    html: `
-                        <div class="page-break"></div>
-                        <div class="imputations-page">
-                            ${headerHtml}
-                            <table class="imps-table">
-                                <thead>
-                                    <tr>
-                                        <th class="date-col">FECHA</th>
-                                        <th class="task-col">TAREA</th>
-                                        <th class="desc-col">DESCRIPCIÓN</th>
-                                        <th class="qty-col">CANTIDAD</th>
-                                        <th class="nocharge-col">SIN CARGO</th>
-                                    </tr>
-                                </thead>
-                                <tbody>${pageRows}</tbody>
-                            </table>
-                            <div class="imps-footer">Página {{PAGE_NUM}} de {{PAGE_TOTAL}}</div>
-                        </div>`
+                // Normalizar la fecha de la imputación
+                const impDate = imp.date instanceof Date ? imp.date : new Date(imp.date);
+                const task = tasks.find(t => t.id === imp.taskId);
+
+                // Obtener año y mes normalizados
+                const impYear = impDate.getFullYear();
+                const impMonth = impDate.getMonth();
+                const invYear = invoiceDate.getFullYear();
+                const invMonth = invoiceDate.getMonth();
+
+                const matchYear = impYear === invYear;
+                const matchMonth = impMonth === invMonth;
+                const matchCustomer = task && task.customerNo === inv.customerNo;
+
+                console.log(i18n.t('Evaluando imputación:'), {
+                    id: imp.id,
+                    fecha_original: imp.date,
+                    fecha_normalizada: impDate,
+                    año: impYear,
+                    mes: impMonth + 1,
+                    fecha_factura: invoiceDate,
+                    año_factura: invYear,
+                    mes_factura: invMonth + 1,
+                    coincideAño: matchYear,
+                    coincideMes: matchMonth,
+                    coincideCliente: matchCustomer,
+                    taskId: imp.taskId,
+                    task: task,
+                    customerNo: task?.customerNo,
+                    customerFactura: inv.customerNo
                 });
-                idx += rowsThisPage;
-                page++;
-            }
 
-            pageTotal = pageData.length + 1; // +1 por la primera página de la factura
-            impsSectionHtml = pageData
-                .map(p => p.html
-                    .replace('{{PAGE_NUM}}', p.num + 1)
-                    .replace('{{PAGE_TOTAL}}', pageTotal))
-                .join('');
+                const matches = matchYear && matchMonth && matchCustomer;
+                console.log(`Imputación ${imp.id} ${matches ? 'COINCIDE' : 'NO COINCIDE'}`);
+
+                return matches;
+            }).sort((a, b) => {
+                const dateA = a.date instanceof Date ? a.date : new Date(a.date);
+                const dateB = b.date instanceof Date ? b.date : new Date(b.date);
+                return dateA - dateB;
+            });
+
+            console.log('Imputaciones filtradas:', {
+                total: imps.length,
+                imputaciones: imps.map(imp => ({
+                    id: imp.id,
+                    fecha: imp.date,
+                    taskId: imp.taskId,
+                    task: tasks.find(t => t.id === imp.taskId)?.subject
+                }))
+            });
+
+            if (imps.length > 0) {
+                const rowsArray = (inv.arrayLinesInvoicePrint || '').split(',')
+                    .map(n => parseInt(n.trim(), 10))
+                    .filter(n => !isNaN(n) && n > 0);
+                const ROWS_PER_PAGE_DEFAULT = 25;
+                const rowsPerPage = rowsArray.length > 0 ? rowsArray : [ROWS_PER_PAGE_DEFAULT];
+                const headerHtml = `
+                    <header class="main-header">
+                        <h1>${typeLabel}</h1>
+                        <div class="invoice-details">
+                            <div><span>FECHA:</span> <span>${fmtDate(inv.date)}</span></div>
+                            <div><span>NÚMERO:</span> <span>${inv.no}</span></div>
+                        </div>
+                    </header>`;
+
+                const makeRow = rec => {
+                    const task = tasks.find(t => t.id === rec.taskId) || {};
+                    const sinCargo = (rec.noFee || task.noCharge) ? i18n.t('Sí') : '';
+                    const taskLabel = task.clientTaskNo || task.subject || '';
+                    return `<tr>
+                        <td>${fmtDate(rec.date)}</td>
+                        <td>${taskLabel}</td>
+                        <td>${rec.comments || ''}</td>
+                        <td style="text-align: right;">${fmtNum(rec.totalDecimal)}</td>
+                        <td style="text-align: center;">${sinCargo}</td>
+                    </tr>`;
+                };
+
+                const pageData = [];
+                let idx = 0;
+                let page = 0;
+                while (idx < imps.length) {
+                    const rowsThisPage = rowsPerPage[Math.min(page, rowsPerPage.length - 1)];
+                    const pageRows = imps.slice(idx, idx + rowsThisPage).map(makeRow).join('');
+                    pageData.push({
+                        num: page + 1,
+                        html: `
+                            <div class="page-break"></div>
+                            <div class="imputations-page">
+                                ${headerHtml}
+                                <table class="imps-table">
+                                    <thead>
+                                        <tr>
+                                            <th class="date-col">FECHA</th>
+                                            <th class="task-col">TAREA</th>
+                                            <th class="desc-col">DESCRIPCIÓN</th>
+                                            <th class="qty-col">CANTIDAD</th>
+                                            <th class="nocharge-col">SIN CARGO</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>${pageRows}</tbody>
+                                </table>
+                                <div class="imps-footer">Página {{PAGE_NUM}} de {{PAGE_TOTAL}}</div>
+                            </div>`
+                    });
+                    idx += rowsThisPage;
+                    page++;
+                }
+
+                pageTotal = pageData.length + 1; // +1 por la primera página de la factura
+                impsSectionHtml = pageData
+                    .map(p => p.html
+                        .replace('{{PAGE_NUM}}', p.num + 1)
+                        .replace('{{PAGE_TOTAL}}', pageTotal))
+                    .join('');
+            }
         }
 
         // --- Ensamblar el HTML final ---
         const finalHtml = template
+            .replace(/{{TYPE}}/g, typeLabel)
             .replace(/{{NO}}/g, inv.no)
             .replace('{{DATE}}', fmtDate(inv.date))
             .replace('{{SELLER}}', sellerHtml)

--- a/js/invoices.js
+++ b/js/invoices.js
@@ -71,7 +71,7 @@ function openInvoicesPopup() {
       function handleEsc(e) { if (e.key === 'Escape') closePopup(); }
       document.addEventListener('keydown', handleEsc);
 
-      let selectedNo = invoices.length ? invoices.slice().sort((a, b) => b.date.localeCompare(a.date))[0].no : null;
+      let selectedNo = invoices.length ? invoices.slice().sort((a, b) => compareInvoiceNo(b.no, a.no))[0].no : null;
 
       function renderYearOptions() {
         const years = Array.from(new Set(invoices.map(i => i.date.substring(0, 4))));
@@ -96,8 +96,8 @@ function openInvoicesPopup() {
         const list = invoices
           .filter(inv => inv.date.startsWith(year))
           .slice()
-          .sort((a, b) => b.date.localeCompare(a.date))
-        if (selectedNo === null && list.length) selectedNo = list[0].no;
+          .sort((a, b) => compareInvoiceNo(a.no, b.no));
+        if (selectedNo === null && list.length) selectedNo = list[list.length - 1].no;
         list.forEach(inv => {
           const cust = customers.find(c => c.no === inv.customerNo);
           const tr = document.createElement('tr');
@@ -203,7 +203,7 @@ function openInvoiceModal(invoice = null, onSave) {
       inp.addEventListener('focus', () => { inp.dataset.prev = inp.value; });
       inp.addEventListener('blur', () => {
         const raw = inp.value.trim();
-        if (raw.includes(',') || !/^\d+(?:\.\d+)?$/.test(raw)) {
+        if (raw.includes(',') || !/^-?\d+(?:\.\d+)?$/.test(raw)) {
           alert(i18n.t('Cantidad inválida'));
           inp.value = inp.dataset.prev || '';
           return;


### PR DESCRIPTION
## Summary
- Allow negative quantities when editing invoice lines
- Mark invoices with negative totals as rectifying and skip imputation pages when printing
- Sort invoice listing by invoice number

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1525f08833099c79d0808dab80b