### PR TITLE
Improve task duplication flow and add bulk status controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -560,12 +560,12 @@ tbody tr.selected {
   opacity: .6;
 }
 
-#taskForm.task-readonly input,
+#taskForm.task-readonly input:not([name="completed"]),
 #taskForm.task-readonly select {
   cursor: not-allowed;
 }
 
-#taskForm.task-readonly .Buttons {
+#taskForm.task-readonly button:not([type="submit"]) {
   pointer-events: none;
   opacity: .5;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -382,6 +382,24 @@ tbody tr.selected {
   background: #cfe8ff !important;
 }
 
+#tasksTable th.select-col,
+#tasksTable td.select-cell {
+  width: 48px;
+  text-align: center;
+}
+
+#tasksTable td.select-cell input {
+  cursor: pointer;
+}
+
+#tasksTable tbody tr.bulk-selected:not(.selected) {
+  background: #fff1d6;
+}
+
+#tasksTable tbody tr.selected.bulk-selected {
+  box-shadow: inset 0 0 0 2px #ffb347;
+}
+
 #invoiceTotals {
   font-size: .9rem;
   font-weight: 600;
@@ -521,6 +539,35 @@ tbody tr.selected {
   border-radius: 6px;
   font-size: .8rem;
   background: #f9fafb;
+}
+
+.task-duplicate-banner {
+  grid-column: 1 / 3;
+  background: #ffe3e3;
+  color: #b00020;
+  font-weight: 700;
+  text-align: center;
+  padding: .85rem 1rem;
+  border-radius: 10px;
+  border: 1px solid #ffb3b3;
+  font-size: 1.1rem;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  margin-bottom: .5rem;
+}
+
+#taskForm.task-readonly label {
+  opacity: .6;
+}
+
+#taskForm.task-readonly input,
+#taskForm.task-readonly select {
+  cursor: not-allowed;
+}
+
+#taskForm.task-readonly .Buttons {
+  pointer-events: none;
+  opacity: .5;
 }
 
 .modal input:focus,

--- a/html/tasks.html
+++ b/html/tasks.html
@@ -20,6 +20,8 @@
                 <button class="Buttons primary" id="BtnEditTask" type="button" disabled>Editar</button>
                 <button class="Buttons" id="BtnDupTask" type="button" disabled>Duplicar</button>
                 <button class="Buttons" id="BtnDelTask" type="button" disabled>Eliminar</button>
+                <button class="Buttons primary" id="BtnCompleteSelected" type="button" disabled>Completar seleccionadas</button>
+                <button class="Buttons" id="BtnUncompleteSelected" type="button" disabled>Marcar como pendientes</button>
             </div>
         </div>
         <div style="margin-bottom:0.5rem">
@@ -35,9 +37,11 @@
         <table id="tasksTable">
             <thead>
                 <tr>
+                    <th class="select-col">Sel.</th>
                     <th>Id</th>
                     <th>Nº tarea cliente</th>
                     <th>Asunto</th>
+                    <th>Sprint</th>
                     <th>Nº cliente</th>
                     <th>Sin cargo</th>
                     <th>Completado</th>
@@ -62,7 +66,7 @@
                             <input type="text" name="subject" required />
                         </label>
                         <label class="full">Comentario para imputación
-                            <input type="text" name="taskDescription" required />
+                            <input type="text" name="taskDescription" />
                         </label>
                         <label class="check">
                             <input type="checkbox" name="noCharge" /> Tarea sin cargo

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -26,6 +26,8 @@ function openTasksPopup() {
       const btnEdit = backdrop.querySelector("#BtnEditTask");
       const btnDup = backdrop.querySelector("#BtnDupTask");
       const btnDel = backdrop.querySelector("#BtnDelTask");
+      const btnCompleteSelected = backdrop.querySelector("#BtnCompleteSelected");
+      const btnUncompleteSelected = backdrop.querySelector("#BtnUncompleteSelected");
       const statusFilter = backdrop.querySelector("#taskStatusFilter");
       const searchInput = backdrop.querySelector("#taskSearchFilter");
       const closeBtn = backdrop.querySelector(".close");
@@ -41,19 +43,42 @@ function openTasksPopup() {
       document.addEventListener('keydown', handleEsc);
 
       let selectedTaskId = tasks.length ? tasks.slice().sort((a, b) => b.id - a.id)[0].id : null;
+      let bulkSelection = new Set();
 
       function updateButtons() {
         const hasSel = !!selectedTaskId;
         btnEdit.disabled = !hasSel;
         btnDup.disabled = !hasSel;
         btnDel.disabled = !hasSel;
+        const hasBulk = bulkSelection.size > 0;
+        btnCompleteSelected.disabled = !hasBulk;
+        btnUncompleteSelected.disabled = !hasBulk;
+      }
+
+      async function bulkSetCompletion(flag) {
+        if (!bulkSelection.size) return;
+        const ids = Array.from(bulkSelection);
+        try {
+          for (const id of ids) {
+            await db.update('tasks', { id }, { completed: flag });
+          }
+          await loadFromDb();
+          bulkSelection.clear();
+          renderTasks();
+          renderImputations();
+        } catch (err) {
+          console.error(err);
+          alert('Error al actualizar las tareas seleccionadas');
+        }
       }
 
 
       function renderTasks() {
         tasksTableBody.innerHTML = "";
+        const existing = new Set(tasks.map(t => t.id));
+        bulkSelection = new Set(Array.from(bulkSelection).filter(id => existing.has(id)));
         let list = tasks.slice().sort((a, b) => b.id - a.id);
-        if (selectedTaskId === null && list.length) selectedTaskId = list[0].id;
+        if ((selectedTaskId === null || !existing.has(selectedTaskId)) && list.length) selectedTaskId = list[0].id;
         const st = statusFilter.value;
         if (st === 'completed') list = list.filter(t => t.completed);
         else if (st === 'incomplete') list = list.filter(t => !t.completed);
@@ -63,15 +88,37 @@ function openTasksPopup() {
             return Object.values(t).some(v => v && String(v).toLowerCase().includes(txt));
           });
         }
+        const visibleIds = new Set(list.map(t => t.id));
+        bulkSelection = new Set(Array.from(bulkSelection).filter(id => visibleIds.has(id)));
+        if (selectedTaskId !== null && !visibleIds.has(selectedTaskId)) {
+          selectedTaskId = list.length ? list[0].id : null;
+        }
+        if (!list.length) selectedTaskId = null;
         list.forEach(t => {
           const tr = document.createElement('tr');
           tr.dataset.id = t.id;
-          const shortSub = t.subject.length > 20 ? t.subject.slice(0, 20) + '…' : t.subject;
-          tr.innerHTML = `<td>${t.id}</td><td>${t.clientTaskNo || ''}</td><td>${shortSub}</td>` +
+          const selectCell = document.createElement('td');
+          selectCell.className = 'select-cell';
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.checked = bulkSelection.has(t.id);
+          checkbox.addEventListener('click', e => e.stopPropagation());
+          checkbox.addEventListener('change', () => {
+            if (checkbox.checked) bulkSelection.add(t.id); else bulkSelection.delete(t.id);
+            tr.classList.toggle('bulk-selected', checkbox.checked);
+            updateButtons();
+          });
+          selectCell.appendChild(checkbox);
+          tr.appendChild(selectCell);
+          const subject = t.subject || '';
+          const shortSub = subject.length > 20 ? subject.slice(0, 20) + '…' : subject;
+          tr.insertAdjacentHTML('beforeend', `<td>${t.id}</td><td>${t.clientTaskNo || ''}</td><td>${shortSub}</td>` +
+            `<td>${t.sprint || ''}</td>` +
             `<td>${t.customerNo || ''}</td>` +
             `<td>${t.noCharge ? i18n.t('Sí') : i18n.t('No')}</td>` +
-            `<td>${t.completed ? i18n.t('Sí') : i18n.t('No')}</td>`;
+            `<td>${t.completed ? i18n.t('Sí') : i18n.t('No')}</td>`);
           if (t.id === selectedTaskId) tr.classList.add('selected');
+          if (bulkSelection.has(t.id)) tr.classList.add('bulk-selected');
           tr.addEventListener('click', () => { selectedTaskId = t.id; renderTasks(); });
           tr.addEventListener('dblclick', () => { openTaskModal(t, id => { selectedTaskId = id; renderTasks(); }); });
           tasksTableBody.appendChild(tr);
@@ -87,11 +134,13 @@ function openTasksPopup() {
         const task = tasks.find(t => t.id === selectedTaskId);
         if (task) openTaskModal(task, id => { selectedTaskId = id; renderTasks(); });
       });
-      btnDup.addEventListener("click", async () => {
+      btnDup.addEventListener("click", () => {
         if (!selectedTaskId) return;
-        const copy = await duplicateTask(selectedTaskId);
-        if (copy) openTaskModal(copy, id => { selectedTaskId = id; renderTasks(); });
+        const copy = duplicateTask(selectedTaskId);
+        if (copy) openTaskModal(null, id => { selectedTaskId = id; renderTasks(); }, { initialData: copy, mode: 'duplicate' });
       });
+      btnCompleteSelected.addEventListener('click', () => { bulkSetCompletion(true); });
+      btnUncompleteSelected.addEventListener('click', () => { bulkSetCompletion(false); });
       btnDel.addEventListener("click", () => {
         if (!selectedTaskId) return;
         if (confirm(i18n.t("¿Eliminar tarea?"))) {
@@ -121,26 +170,77 @@ function openTasksPopup() {
 function duplicateTask(id) {
   const original = tasks.find(t => t.id === id);
   if (!original) return null;
-  const copy = sanitizeStrings({ ...original, id: taskSeq++ });
-  return db.insert('tasks', copy)
-    .then(rec => { loadFromDb(); return rec; })
-    .catch(err => { console.error(err); alert('Error al duplicar'); return null; });
+  const copy = sanitizeStrings({
+    ...original,
+    id: taskSeq,
+    subject: '',
+    taskDescription: '',
+    clientTaskDesc: '',
+    completed: false
+  });
+  return copy;
 }
 
-function openTaskModal(task = null, onSave) {
+function openTaskModal(task = null, onSave, options = {}) {
   const tmpl = (currentTasksBackdrop || document).querySelector("#taskModalTmpl");
   const clone = tmpl.content.cloneNode(true);
   const backdrop = clone.querySelector(".modal-backdrop");
   const form = clone.querySelector("#taskForm");
   const customerSel = form.elements["customerNo"];
   customerSel.innerHTML = '<option value=""></option>' + customers.map(c => `<option value="${c.no}">${c.no} - ${c.name}</option>`).join('');
+  form.reset();
+  const { initialData = null, mode = null } = options;
+  const applyValues = data => {
+    Object.entries(data || {}).forEach(([k, v]) => {
+      const input = form.elements[k];
+      if (!input) return;
+      if (input.type === 'checkbox') input.checked = !!v;
+      else input.value = v != null ? v : '';
+    });
+  };
   if (task) {
-    Object.entries(task).forEach(([k, v]) => { if (form.elements[k] != null) form.elements[k].value = v; });
-    form.elements["noCharge"].checked = !!task.noCharge;
-    form.elements["completed"].checked = !!task.completed;
+    applyValues(task);
     backdrop.querySelector(".modal-title").textContent = "Editar tarea";
   } else {
-    form.elements["id"].value = taskSeq;
+    const init = initialData ? { ...initialData } : {};
+    if (init.id == null) init.id = taskSeq;
+    applyValues(init);
+  }
+  if (mode === 'duplicate') {
+    const banner = document.createElement('div');
+    banner.className = 'task-duplicate-banner';
+    banner.textContent = 'Estás duplicando esta tarea. Introduce los nuevos datos.';
+    form.insertBefore(banner, form.firstElementChild);
+  }
+
+  if (task && task.completed) {
+    form.classList.add('task-readonly');
+    let warned = false;
+    const warn = () => {
+      if (!warned) {
+        warned = true;
+        alert('Esta tarea está completada y no se puede modificar.');
+      }
+    };
+    const block = e => {
+      if (e) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+      warn();
+      if (document.activeElement && typeof document.activeElement.blur === 'function') {
+        document.activeElement.blur();
+      }
+    };
+    Array.from(form.elements).forEach(el => {
+      if (el.name === 'id') return;
+      if (el.tagName === 'BUTTON') {
+        el.addEventListener('click', block, true);
+      } else {
+        ['focus', 'click', 'keydown', 'input', 'change'].forEach(evt => el.addEventListener(evt, block, true));
+      }
+    });
+    form.addEventListener('submit', block, true);
   }
   function closeModal() {
     backdrop.remove();

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -233,14 +233,14 @@ function openTaskModal(task = null, onSave, options = {}) {
       }
     };
     Array.from(form.elements).forEach(el => {
-      if (el.name === 'id') return;
+      if (el.name === 'id' || el.name === 'completed') return;
       if (el.tagName === 'BUTTON') {
+        if (el.type === 'submit') return;
         el.addEventListener('click', block, true);
       } else {
         ['focus', 'click', 'keydown', 'input', 'change'].forEach(evt => el.addEventListener(evt, block, true));
       }
     });
-    form.addEventListener('submit', block, true);
   }
   function closeModal() {
     backdrop.remove();


### PR DESCRIPTION
## Summary
- clear key fields and show a warning banner when duplicating a task
- block editing of completed tasks and allow optional imputation comments
- add sprint column, multi-select checkboxes, and bulk complete/incomplete actions in the task list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbe4fc57b08330a16302d7d1ef9c64